### PR TITLE
Tidy up the Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ bootblock
 *.o
 *.asm
 *.swp
-kernel_bin
-kernel_bin.sym
+*.sym
+*.elf


### PR DESCRIPTION
This adds more granular targets to the Makefile so overall, meaning that
it's able to be a bit smarter about which targets have to be rebuilt.

Ultimately, this should result in much less unnecessary rebuilding of
targets that aren't affected by a certain change.